### PR TITLE
Update rails version to 2.3.15

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,7 +1,7 @@
 require File.join(File.dirname(__FILE__), 'boot')
 
 
-RAILS_GEM_VERSION = '2.3.5' unless defined? RAILS_GEM_VERSION
+RAILS_GEM_VERSION = '2.3.15' unless defined? RAILS_GEM_VERSION
 
 Rails::Initializer.run do |config|
   config.time_zone = 'UTC'


### PR DESCRIPTION
Because of [serious security vulnerability](http://weblog.rubyonrails.org/2013/1/8/Rails-3-2-11-3-1-10-3-0-19-and-2-3-15-have-been-released/) in previous version
